### PR TITLE
Changed verifyBackbone to look for CRM.backbone 

### DIFF
--- a/js/crmProfiles.js
+++ b/js/crmProfiles.js
@@ -110,7 +110,7 @@
       return deferred.promise;
     }
     function verifyBackbone() {
-      return !!window.Backbone;
+      return !!CRM.Backbone;
     }
     function verifyTemplate() {
       return (angular.element("#designer_template").length > 0);


### PR DESCRIPTION
This fixes issues when a CMS instance loads it's own version of backbone, but not marionette and not the civi backbone helpers.
