### PR TITLE
Fixes breakage introduced by Backbone.noConflict() (CiviCRM 4.7.31)

### DIFF
--- a/angularprofiles.civix.php
+++ b/angularprofiles.civix.php
@@ -3,6 +3,83 @@
 // AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
 
 /**
+ * The ExtensionUtil class provides small stubs for accessing resources of this
+ * extension.
+ */
+class CRM_AngularProfiles_ExtensionUtil {
+  const SHORT_NAME = "angularprofiles";
+  const LONG_NAME = "org.civicrm.angularprofiles";
+  const CLASS_PREFIX = "CRM_AngularProfiles";
+
+  /**
+   * Translate a string using the extension's domain.
+   *
+   * If the extension doesn't have a specific translation
+   * for the string, fallback to the default translations.
+   *
+   * @param string $text
+   *   Canonical message text (generally en_US).
+   * @param array $params
+   * @return string
+   *   Translated text.
+   * @see ts
+   */
+  public static function ts($text, $params = array()) {
+    if (!array_key_exists('domain', $params)) {
+      $params['domain'] = array(self::LONG_NAME, NULL);
+    }
+    return ts($text, $params);
+  }
+
+  /**
+   * Get the URL of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function url($file = NULL) {
+    if ($file === NULL) {
+      return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
+    }
+    return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
+  }
+
+  /**
+   * Get the path of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo'.
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function path($file = NULL) {
+    // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
+    return __DIR__ . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+  }
+
+  /**
+   * Get the name of a class within this extension.
+   *
+   * @param string $suffix
+   *   Ex: 'Page_HelloWorld' or 'Page\\HelloWorld'.
+   * @return string
+   *   Ex: 'CRM_Foo_Page_HelloWorld'.
+   */
+  public static function findClass($suffix) {
+    return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
+  }
+
+}
+
+use CRM_AngularProfiles_ExtensionUtil as E;
+
+/**
  * (Delegated) Implements hook_civicrm_config().
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_config
@@ -19,14 +96,14 @@ function _angularprofiles_civix_civicrm_config(&$config = NULL) {
   $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
 
-  if ( is_array( $template->template_dir ) ) {
-      array_unshift( $template->template_dir, $extDir );
+  if (is_array($template->template_dir)) {
+    array_unshift($template->template_dir, $extDir);
   }
   else {
-      $template->template_dir = array( $extDir, $template->template_dir );
+    $template->template_dir = array($extDir, $template->template_dir);
   }
 
-  $include_path = $extRoot . PATH_SEPARATOR . get_include_path( );
+  $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
   set_include_path($include_path);
 }
 
@@ -52,6 +129,20 @@ function _angularprofiles_civix_civicrm_install() {
   _angularprofiles_civix_civicrm_config();
   if ($upgrader = _angularprofiles_civix_upgrader()) {
     $upgrader->onInstall();
+  }
+}
+
+/**
+ * Implements hook_civicrm_postInstall().
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_postInstall
+ */
+function _angularprofiles_civix_civicrm_postInstall() {
+  _angularprofiles_civix_civicrm_config();
+  if ($upgrader = _angularprofiles_civix_upgrader()) {
+    if (is_callable(array($upgrader, 'onPostInstall'))) {
+      $upgrader->onPostInstall();
+    }
   }
 }
 
@@ -117,7 +208,7 @@ function _angularprofiles_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NU
  * @return CRM_AngularProfiles_Upgrader
  */
 function _angularprofiles_civix_upgrader() {
-  if (!file_exists(__DIR__.'/CRM/AngularProfiles/Upgrader.php')) {
+  if (!file_exists(__DIR__ . '/CRM/AngularProfiles/Upgrader.php')) {
     return NULL;
   }
   else {
@@ -153,7 +244,8 @@ function _angularprofiles_civix_find_files($dir, $pattern) {
       while (FALSE !== ($entry = readdir($dh))) {
         $path = $subdir . DIRECTORY_SEPARATOR . $entry;
         if ($entry{0} == '.') {
-        } elseif (is_dir($path)) {
+        }
+        elseif (is_dir($path)) {
           $todos[] = $path;
         }
       }
@@ -175,9 +267,12 @@ function _angularprofiles_civix_civicrm_managed(&$entities) {
     $es = include $file;
     foreach ($es as $e) {
       if (empty($e['module'])) {
-        $e['module'] = 'org.civicrm.angularprofiles';
+        $e['module'] = E::LONG_NAME;
       }
       $entities[] = $e;
+      if (empty($e['params']['version'])) {
+        $e['params']['version'] = '3';
+      }
     }
   }
 }
@@ -204,7 +299,7 @@ function _angularprofiles_civix_civicrm_caseTypes(&$caseTypes) {
       // throw new CRM_Core_Exception($errorMessage);
     }
     $caseTypes[$name] = array(
-      'module' => 'org.civicrm.angularprofiles',
+      'module' => E::LONG_NAME,
       'name' => $name,
       'file' => $file,
     );
@@ -212,14 +307,14 @@ function _angularprofiles_civix_civicrm_caseTypes(&$caseTypes) {
 }
 
 /**
-* (Delegated) Implements hook_civicrm_angularModules().
-*
-* Find any and return any files matching "ang/*.ang.php"
-*
-* Note: This hook only runs in CiviCRM 4.5+.
-*
-* @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
-*/
+ * (Delegated) Implements hook_civicrm_angularModules().
+ *
+ * Find any and return any files matching "ang/*.ang.php"
+ *
+ * Note: This hook only runs in CiviCRM 4.5+.
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
+ */
 function _angularprofiles_civix_civicrm_angularModules(&$angularModules) {
   if (!is_dir(__DIR__ . '/ang')) {
     return;
@@ -230,7 +325,7 @@ function _angularprofiles_civix_civicrm_angularModules(&$angularModules) {
     $name = preg_replace(':\.ang\.php$:', '', basename($file));
     $module = include $file;
     if (empty($module['ext'])) {
-      $module['ext'] = 'org.civicrm.angularprofiles';
+      $module['ext'] = E::LONG_NAME;
     }
     $angularModules[$name] = $module;
   }
@@ -259,37 +354,75 @@ function _angularprofiles_civix_glob($pattern) {
  * @param array $menu - menu hierarchy
  * @param string $path - path where insertion should happen (ie. Administer/System Settings)
  * @param array $item - menu you need to insert (parent/child attributes will be filled for you)
- * @param int $parentId - used internally to recurse in the menu structure
  */
-function _angularprofiles_civix_insert_navigation_menu(&$menu, $path, $item, $parentId = NULL) {
-  static $navId;
-
+function _angularprofiles_civix_insert_navigation_menu(&$menu, $path, $item) {
   // If we are done going down the path, insert menu
   if (empty($path)) {
-    if (!$navId) $navId = CRM_Core_DAO::singleValueQuery("SELECT max(id) FROM civicrm_navigation");
-    $navId ++;
-    $menu[$navId] = array (
-      'attributes' => array_merge($item, array(
+    $menu[] = array(
+      'attributes' => array_merge(array(
         'label'      => CRM_Utils_Array::value('name', $item),
         'active'     => 1,
-        'parentID'   => $parentId,
-        'navID'      => $navId,
-      ))
+      ), $item),
     );
-    return true;
+    return TRUE;
   }
   else {
     // Find an recurse into the next level down
-    $found = false;
+    $found = FALSE;
     $path = explode('/', $path);
     $first = array_shift($path);
     foreach ($menu as $key => &$entry) {
       if ($entry['attributes']['name'] == $first) {
-        if (!$entry['child']) $entry['child'] = array();
+        if (!isset($entry['child'])) {
+          $entry['child'] = array();
+        }
         $found = _angularprofiles_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item, $key);
       }
     }
     return $found;
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_navigationMenu().
+ */
+function _angularprofiles_civix_navigationMenu(&$nodes) {
+  if (!is_callable(array('CRM_Core_BAO_Navigation', 'fixNavigationMenu'))) {
+    _angularprofiles_civix_fixNavigationMenu($nodes);
+  }
+}
+
+/**
+ * Given a navigation menu, generate navIDs for any items which are
+ * missing them.
+ */
+function _angularprofiles_civix_fixNavigationMenu(&$nodes) {
+  $maxNavID = 1;
+  array_walk_recursive($nodes, function($item, $key) use (&$maxNavID) {
+    if ($key === 'navID') {
+      $maxNavID = max($maxNavID, $item);
+    }
+  });
+  _angularprofiles_civix_fixNavigationMenuItems($nodes, $maxNavID, NULL);
+}
+
+function _angularprofiles_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) {
+  $origKeys = array_keys($nodes);
+  foreach ($origKeys as $origKey) {
+    if (!isset($nodes[$origKey]['attributes']['parentID']) && $parentID !== NULL) {
+      $nodes[$origKey]['attributes']['parentID'] = $parentID;
+    }
+    // If no navID, then assign navID and fix key.
+    if (!isset($nodes[$origKey]['attributes']['navID'])) {
+      $newKey = ++$maxNavID;
+      $nodes[$origKey]['attributes']['navID'] = $newKey;
+      $nodes[$newKey] = $nodes[$origKey];
+      unset($nodes[$origKey]);
+      $origKey = $newKey;
+    }
+    if (isset($nodes[$origKey]['child']) && is_array($nodes[$origKey]['child'])) {
+      _angularprofiles_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
+    }
   }
 }
 
@@ -306,7 +439,7 @@ function _angularprofiles_civix_civicrm_alterSettingsFolders(&$metaDataFolders =
   $configured = TRUE;
 
   $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if(is_dir($settingsDir) && !in_array($settingsDir, $metaDataFolders)) {
+  if (is_dir($settingsDir) && !in_array($settingsDir, $metaDataFolders)) {
     $metaDataFolders[] = $settingsDir;
   }
 }

--- a/angularprofiles.php
+++ b/angularprofiles.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once 'angularprofiles.civix.php';
+use CRM_AngularProfiles_ExtensionUtil as E;
 
 /**
  * Implementation of hook_civicrm_config
@@ -115,9 +116,20 @@ function angularprofiles_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) 
  * @param $angularModule
  */
 function angularprofiles_civicrm_angularModules(&$angularModule) {
+  // Using this hook as the place to call addVars is a bit of a hack. Ideally
+  // we'd have a more precise way to target exactly the contexts in which the
+  // data are needed on the client side, but the location is very convenient for
+  // our purposes, as:
+  //   1. The extension resource URL is not available client side by default.
+  //   2. This extension needs it when and only when Angular modules are loaded.
+  CRM_Core_Resources::singleton()->addVars(E::LONG_NAME, array(
+    'backboneInitUrl' => E::url('js/initBackbone.js'),
+  ));
+  // End hack.
+
   $angularModule['crmProfileUtils'] = array(
     'ext' => 'org.civicrm.angularprofiles',
-    'js' => array('js/*.js'),
+    'js' => array('js/crmProfiles.js'),
     'partials' => array('partials'),
   );
 }

--- a/info.xml
+++ b/info.xml
@@ -5,14 +5,13 @@
   <description>A Utility extension that provides Profile support to AngularJS pages</description>
   <license>AGPL-3.0</license>
   <maintainer>
-    <author>Tobias Lounsbury</author>
-    <email>toby@ginkgostreet.com</email>
+    <author>Ginkgo Street Labs</author>
+    <email>inquire@ginkgostreet.com</email>
   </maintainer>
-  <releaseDate>2016-06-20</releaseDate>
-  <version>4.6-1.0.2</version>
+  <releaseDate>2018-03-23</releaseDate>
+  <version>4.7.31-1.1.0</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>4.6</ver>
     <ver>4.7</ver>
   </compatibility>
   <comments>

--- a/js/crmProfiles.js
+++ b/js/crmProfiles.js
@@ -7,7 +7,9 @@
     //Must execute in order.
     function loadNextScript(scripts, callback, fail) {
       var script = scripts.shift();
-      CRM.$.getScript(CRM.config.resourceBase + script.url)
+      script.url = script.url.indexOf('http') === 0 ? script.url : CRM.config.resourceBase + script.url;
+
+      CRM.$.getScript(script.url)
         .done(function(scriptData, status) {
           if(scripts.length) {
             loadNextScript(scripts, callback, fail);
@@ -34,6 +36,7 @@
         {url: 'packages/backbone-forms/distribution/backbone-forms.js', weight: 130},
         {url: 'packages/backbone-forms/distribution/adapters/backbone.bootstrap-modal.min.js', weight: 140},
         {url: 'packages/backbone-forms/distribution/editors/list.min.js', weight: 140},
+        {url: CRM.vars['org.civicrm.angularprofiles'].backboneInitUrl, weight: 145},
         {url: 'js/crm.backbone.js', weight: 150},
         {url: 'js/model/crm.schema-mapped.js', weight: 200},
         {url: 'js/model/crm.uf.js', weight: 200},

--- a/js/initBackbone.js
+++ b/js/initBackbone.js
@@ -1,0 +1,7 @@
+// CiviCRM loads Backbone very conservatively/inconsistently. We load it here
+// so that we can make the Profiles widget available in Angular contexts where
+// core hasn't already made Backbone available through the CRM object, but do so
+// conditionally in case core starts providing it more consistently.
+if (!CRM.hasOwnProperty('BB')) {
+  CRM.BB = Backbone.noConflict();
+}


### PR DESCRIPTION
Detailed in #13.

I believe this should be backward-compatible. CiviCRM versions prior to 4.7.31 don't define `CRM.BB` or make use of `Backbone.noConflict()` though the method has existed since Backbone v0.5.0 (2011).

No need to review the changes in angularprofiles.civix.php -- just updating the boilerplate.