### PR TITLE
Remove hack from hook_angularModules, use settings

### DIFF
--- a/angularprofiles.php
+++ b/angularprofiles.php
@@ -116,20 +116,12 @@ function angularprofiles_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) 
  * @param $angularModule
  */
 function angularprofiles_civicrm_angularModules(&$angularModule) {
-  // Using this hook as the place to call addVars is a bit of a hack. Ideally
-  // we'd have a more precise way to target exactly the contexts in which the
-  // data are needed on the client side, but the location is very convenient for
-  // our purposes, as:
-  //   1. The extension resource URL is not available client side by default.
-  //   2. This extension needs it when and only when Angular modules are loaded.
-  CRM_Core_Resources::singleton()->addVars(E::LONG_NAME, array(
-    'backboneInitUrl' => E::url('js/initBackbone.js'),
-  ));
-  // End hack.
-
-  $angularModule['crmProfileUtils'] = array(
-    'ext' => 'org.civicrm.angularprofiles',
-    'js' => array('js/crmProfiles.js'),
-    'partials' => array('partials'),
-  );
+  $angularModule['crmProfileUtils'] = [
+    'ext' => E::LONG_NAME,
+    'js' => ['js/crmProfiles.js'],
+    'partials' => ['partials'],
+    'settings' => [
+      'backboneInitUrl' => E::url('js/initBackbone.js'),
+    ],
+  ];
 }

--- a/js/crmProfiles.js
+++ b/js/crmProfiles.js
@@ -37,7 +37,7 @@
         {url: 'packages/backbone-forms/distribution/backbone-forms.js', weight: 130},
         {url: 'packages/backbone-forms/distribution/adapters/backbone.bootstrap-modal.min.js', weight: 140},
         {url: 'packages/backbone-forms/distribution/editors/list.min.js', weight: 140},
-        {url: CRM.vars['org.civicrm.angularprofiles'].backboneInitUrl, weight: 145},
+        {url: CRM.crmProfileUtils.backboneInitUrl, weight: 145},
         {url: 'js/crm.backbone.js', weight: 150},
         {url: 'js/model/crm.schema-mapped.js', weight: 200},
         {url: 'js/model/crm.uf.js', weight: 200},


### PR DESCRIPTION
`hook_civicrm_angularModules` contained an unnecessary hack to pass a setting to the client-side. But there is already a standard way to do this, using the `settings` key.